### PR TITLE
Linux admin web panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ DIY parental control system for parents who code. If you know what 'pip install'
 
 ![Python](https://img.shields.io/badge/python-3.7+-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
-![Platform](https://img.shields.io/badge/platform-Windows-lightgrey.svg)
+![Kids PC](https://img.shields.io/badge/kids_PC-Windows-lightgrey.svg)
+![Web panel](https://img.shields.io/badge/web_panel-Windows%20%7C%20Linux%20%7C%20macOS-green.svg)
 
 ## 🎯 Features
 
@@ -31,10 +32,10 @@ DIY parental control system for parents who code. If you know what 'pip install'
 
 This is NOT a one-click solution. You'll need to:
 - Install Python
-- Use command prompt
-- Understand IP addresses  
-- Configure Windows Firewall (technically you would simply allow the process to run - once)
-- Set up scheduled task
+- Use a terminal / command prompt
+- Understand IP addresses
+- Open firewall ports where needed (Windows on kid PCs; on Linux parents, e.g. `ufw` or your distro's firewall)
+- On kid PCs: set up a Windows scheduled task (the installer does this)
 
 If these terms scare you, consider commercial alternatives like:
 - Qustodio
@@ -42,9 +43,11 @@ If these terms scare you, consider commercial alternatives like:
 - Windows Family Safety
 
 ### Prerequisites
-- Windows 10/11 PCs (for the kids)
-- Python 3.7+ installed
-- All PCs on the same network
+- **Kid PCs:** Windows 10/11 (the monitoring agent uses Windows APIs)
+- **Parent / admin machine:** Windows, Linux, or macOS with Python 3.7+ (runs the Flask web panel only)
+- **Network:** Kid PCs must accept inbound TCP **9999** from the machine running the web panel (usually the same LAN; cross-subnet works if routed and allowed by firewalls). The web panel listens on TCP **5000** for your browser or phone.
+
+Auto-discovery scans the `/24` subnet containing the parent machine's primary IPv4 address (see `scan_for_servers` in `src/web_panel.py`). If discovery misses a PC, you can still use it once the agent is reachable at its IP.
 
 ### Installation
 
@@ -64,7 +67,7 @@ pip install -r requirements.txt
 python scripts/install.py
 ```
 
-2. **On your PC:**
+2. **On your PC (Windows or macOS; for Linux, see the Linux parent steps below):**
 ```bash
 git clone https://github.com/rookie7799/kid-pc-monitor.git
 cd kid-pc-monitor/src
@@ -73,6 +76,22 @@ python web_panel.py
 
 # Open in browser: http://YOUR-PC-IP:5000
 ```
+
+**Linux parent machine:** The web panel does not require `pywin32`; `requirements.txt` installs it only on Windows. From the repo root:
+
+```bash
+git clone https://github.com/rookie7799/kid-pc-monitor.git
+cd kid-pc-monitor
+python3 -m venv .venv
+source .venv/bin/activate   # On Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+cd src
+python3 web_panel.py
+```
+
+Then open `http://YOUR-LINUX-IP:5000` from your phone or browser. Allow inbound TCP **5000** on the Linux host (example with UFW: `sudo ufw allow 5000/tcp`).
+
+**systemd / service note:** `web_panel.py` writes `templates/` under the process **current working directory** when it is imported. If you run it from a unit file, set `WorkingDirectory=` to the directory you use for `cd` (for example the repo's `src` folder if you start the app from there).
 
 #### Option B: Single PC Setup
 
@@ -178,9 +197,10 @@ This means restrictions **survive PC restarts** - kids can't bypass by rebooting
 - Ensure PCs are on same network
 
 ### "Can't connect from phone"
-- Check firewall allows port 5000 (web panel) and port 9999 (pc_control)
-- Use PC's IP address, not localhost
-- Ensure web_panel.py is running
+- Check firewall allows port 5000 (web panel host) and port 9999 (each kid PC running the agent)
+- On Linux parents, ensure the host firewall allows inbound **5000/tcp** (e.g. `ufw allow 5000/tcp`)
+- Use the web panel machine's IP address, not localhost
+- Ensure `web_panel.py` is running
 
 ### "Lock status not updating"
 - Restart pc_control.py
@@ -211,7 +231,7 @@ Parents and developers welcome! Please:
 - ✅ Better resource management
 
 ### Ideas for Future Contributions
-- macOS/Linux support
+- Linux/macOS **agent** (kid-side monitoring; the web panel already runs on Linux/macOS/Windows)
 - Mobile app
 - Usage statistics/reports
 - Reward system integration

--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ Then open `http://YOUR-LINUX-IP:5000` from your phone or browser. Allow inbound 
 
 **systemd / service note:** `web_panel.py` writes `templates/` under the process **current working directory** when it is imported. If you run it from a unit file, set `WorkingDirectory=` to the directory you use for `cd` (for example the repo's `src` folder if you start the app from there).
 
+**Install as a user service (survives reboot when user lingering is enabled):** from the repo root, after `pip install -r requirements.txt`:
+
+```bash
+chmod +x scripts/install_web_panel_linux.sh
+./scripts/install_web_panel_linux.sh install   # writes ~/.config/systemd/user/kid-pc-monitor-web-panel.service
+./scripts/install_web_panel_linux.sh status
+# ./scripts/install_web_panel_linux.sh uninstall   # when you want it gone
+```
+
+Use `./scripts/install_web_panel_linux.sh cat-unit` to preview the unit. Override the interpreter with `PYTHON=/path/to/python3 ./scripts/install_web_panel_linux.sh install` if you do not use a repo-root `.venv`. For the service to start at boot **before anyone logs in graphically**, run once: `sudo loginctl enable-linger "$USER"`.
+
 #### Option B: Single PC Setup
 
 Run everything on the kid's PC and access the admin panel from your phone. Convenient if you don't have a separate PC always running.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -14,7 +14,8 @@ No! This tool:
 If they have administrator access, yes. This tool is based on trust and communication, not enforcement. For younger kids who don't have admin rights, it's quite effective.
 
 ### Does it work on Mac/Linux?
-Currently Windows only. Mac/Linux support is planned.
+- **Kid PC (monitoring agent):** Windows only today (`pc_control.py` uses Windows-specific lock and session APIs).
+- **Parent web panel:** Runs on **Windows, Linux, or macOS**. Install Python, `pip install -r requirements.txt` (on non-Windows, `pywin32` is skipped automatically), then run `web_panel.py` from `src/`. The panel talks to each kid PC over TCP port **9999** on your network.
 
 ## Setup Issues
 
@@ -24,12 +25,9 @@ Currently Windows only. Mac/Linux support is planned.
 - Restart your computer
 
 ### "Can't connect from my phone"
-1. Check both devices are on same WiFi
-2. Check Windows Firewall:
-   - Open Windows Defender Firewall
-   - Click "Allow an app"
-   - Add Python to the list
-3. Use the IP address shown when starting web_control_panel.py
+1. Check both devices are on same WiFi (or that routing exists between subnets if you use VLANs)
+2. **Firewall:** On Windows (kid PC or a Windows parent), allow Python / ports **5000** (web panel) and **9999** (agent). On a **Linux** machine running the web panel, allow inbound **5000/tcp** (e.g. `sudo ufw allow 5000/tcp` on Ubuntu)
+3. Use the IP address shown when starting `web_panel.py`, not `localhost`, from the other device
 
 ### "PC shows as Unknown"
 This is normal. You can:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 flask>=2.0.0
-pywin32>=300  # For potential future Windows API features
+pywin32>=300; sys_platform == 'win32'  # Windows agent / future Windows APIs (skipped on Linux/macOS)

--- a/scripts/install_web_panel_linux.sh
+++ b/scripts/install_web_panel_linux.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Install the Kid PC Monitor web panel as a systemd --user service (Linux only).
+# Requires: systemd, bash. Uses the repo layout: this file lives in scripts/.
+
+set -euo pipefail
+
+UNIT_NAME="kid-pc-monitor-web-panel.service"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SRC_DIR="$(cd "${REPO_ROOT}/src" && pwd)"
+WEB_PANEL_PY="${SRC_DIR}/web_panel.py"
+UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+UNIT_PATH="${UNIT_DIR}/${UNIT_NAME}"
+
+usage() {
+    cat <<'EOF'
+Usage: install_web_panel_linux.sh <command>
+
+Commands:
+  install     Write a systemd user unit, enable and start the web panel.
+  uninstall   Stop, disable, and remove the user unit.
+  status      Show systemctl --user status.
+  cat-unit    Print the unit file that would be used (no writes).
+
+Environment (optional):
+  PYTHON      Full path to python interpreter (default: .venv, venv, or python3)
+
+The service runs with WorkingDirectory set to the repo's src/ directory so
+Flask templates are written next to web_panel.py, matching manual runs from
+that directory.
+
+Optional — start at boot without an interactive login:
+  sudo loginctl enable-linger "$USER"
+EOF
+}
+
+die() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+require_linux() {
+    case "$(uname -s)" in
+        Linux) ;;
+        *) die "This script is for Linux only (found: $(uname -s))." ;;
+    esac
+}
+
+pick_python() {
+    if [[ -n "${PYTHON:-}" ]]; then
+        [[ -x "$PYTHON" ]] || die "PYTHON is not executable: $PYTHON"
+        echo "$PYTHON"
+        return
+    fi
+    for candidate in \
+        "${REPO_ROOT}/.venv/bin/python3" \
+        "${REPO_ROOT}/.venv/bin/python" \
+        "${REPO_ROOT}/venv/bin/python3" \
+        "${REPO_ROOT}/venv/bin/python"; do
+        if [[ -x "$candidate" ]]; then
+            echo "$candidate"
+            return
+        fi
+    done
+    if command -v python3 >/dev/null 2>&1; then
+        command -v python3
+        return
+    fi
+    die "No usable Python found. Create a venv in the repo root or set PYTHON=/path/to/python3"
+}
+
+require_systemctl_user() {
+    systemctl --user status >/dev/null 2>&1 || die \
+        "systemctl --user failed. Is systemd user session available? Try: loginctl enable-linger \"$USER\" (may require sudo) or log in once with a desktop session."
+}
+
+# Print a systemd user unit to stdout (paths must not contain shell metacharacters).
+render_unit() {
+    local py="$1"
+    [[ -f "$WEB_PANEL_PY" ]] || die "Missing web panel script: $WEB_PANEL_PY"
+    cat <<EOF
+[Unit]
+Description=Kid PC Monitor web panel (parent UI on port 5000)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=${SRC_DIR}
+Environment=PYTHONUNBUFFERED=1
+ExecStart=${py} ${WEB_PANEL_PY}
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+EOF
+}
+
+write_unit() {
+    local py="$1"
+    mkdir -p "$UNIT_DIR"
+    render_unit "$py" >"$UNIT_PATH"
+    echo "Wrote: $UNIT_PATH"
+}
+
+cmd_install() {
+    require_linux
+    require_systemctl_user
+    local py
+    py="$(pick_python)"
+    echo "Using Python: $py"
+    write_unit "$py"
+    systemctl --user daemon-reload
+    systemctl --user enable "$UNIT_NAME"
+    systemctl --user restart "$UNIT_NAME"
+    echo ""
+    echo "Service is enabled and running. Check: systemctl --user status $UNIT_NAME"
+    echo "Open: http://$(hostname -I 2>/dev/null | awk '{print $1}' || echo '<this-host-ip>'):5000"
+    echo ""
+    echo "Firewall (example): sudo ufw allow 5000/tcp"
+    echo "Boot without login (optional): sudo loginctl enable-linger \"$USER\""
+}
+
+cmd_uninstall() {
+    require_linux
+    systemctl --user disable --now "$UNIT_NAME" 2>/dev/null || true
+    rm -f "$UNIT_PATH"
+    systemctl --user daemon-reload
+    echo "Removed $UNIT_NAME (if it was present)."
+}
+
+cmd_status() {
+    require_linux
+    systemctl --user status "$UNIT_NAME" || true
+}
+
+cmd_cat_unit() {
+    require_linux
+    local py
+    py="$(pick_python)"
+    echo "# Preview (not written to disk):"
+    render_unit "$py"
+}
+
+main() {
+    local cmd="${1:-}"
+    case "$cmd" in
+        install) cmd_install ;;
+        uninstall) cmd_uninstall ;;
+        status) cmd_status ;;
+        cat-unit) cmd_cat_unit ;;
+        -h|--help|help) usage ;;
+        *) usage; exit 1 ;;
+    esac
+}
+
+main "$@"

--- a/src/web_panel.py
+++ b/src/web_panel.py
@@ -45,7 +45,7 @@ def check_pc_status(ip, port=9999):
         return "UNKNOWN"
 
 def get_current_user(ip, port=9999):
-    """Get the current Windows username logged in"""
+    """Get the current username logged in on the kid PC (as reported by the agent)."""
     try:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.settimeout(2)


### PR DESCRIPTION
Run the parent Flask web panel on Linux: gate `pywin32` in requirements with a Windows-only marker, document Linux setup and firewall, add `scripts/install_web_panel_linux.sh` for a systemd user service with correct `WorkingDirectory`, and clarify FAQ / docstrings.

Made with [Cursor](https://cursor.com)