### PR TITLE
fix: harden the Windows kid-PC installer so the agent actually runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 .Python
 env/
 venv/
+.venv/
 ENV/
 
 # Flask

--- a/README.md
+++ b/README.md
@@ -247,6 +247,22 @@ This means restrictions **survive PC restarts** - kids can't bypass by rebooting
 
 ## 🔧 Troubleshooting
 
+### Verify the agent is listening (port 9999)
+> **The agent only starts after the kid logs in.** It runs inside the kid's
+> desktop session, so right after installation — while you're still signed in as
+> the admin — it is **not** running yet, and that's expected. Log in as the
+> **kid's** account first (or, if that account is already signed in, run
+> `schtasks /run /tn "KidPCMonitor"`).
+
+Once logged in as the kid, confirm the agent is listening:
+
+```cmd
+netstat -an | findstr 9999
+```
+
+You should see a line like `TCP    0.0.0.0:9999    0.0.0.0:0    LISTENING`. If
+nothing shows up, see the task-troubleshooting note below.
+
 ### "PC shows as Unknown"
 - Add custom names in configuration
 - Check Windows Firewall settings

--- a/README.md
+++ b/README.md
@@ -61,11 +61,15 @@ Run the web panel on a separate PC (your own computer). More secure since kids c
 ```bash
 git clone https://github.com/rookie7799/kid-pc-monitor.git
 cd kid-pc-monitor
-pip install -r requirements.txt
 
 # Run installer as administrator
 python scripts/install.py
 ```
+
+> **No `pip install` needed here.** The monitoring agent (`pc_control.py`) and
+> the installer use only the Python standard library, so kid PCs just need
+> Python itself. `requirements.txt` (Flask) is only for the machine that runs
+> the web panel — see step 2.
 
 > ⚠️ **IMPORTANT — enter the KID's account, not yours.** The installer must run
 > elevated, so it is usually launched from a **parent/admin** account. But the
@@ -84,14 +88,35 @@ python scripts/install.py
 > **kid's** account.
 
 2. **On your PC (Windows or macOS; for Linux, see the Linux parent steps below):**
+
+The web panel needs Flask. Best practice is to install it into an isolated
+**virtual environment** rather than your system Python, so dependencies don't
+clash with other projects:
+
 ```bash
 git clone https://github.com/rookie7799/kid-pc-monitor.git
-cd kid-pc-monitor/src
-pip install -r ../requirements.txt
+cd kid-pc-monitor
+
+# Create and activate a virtual environment (best practice)
+python -m venv .venv
+.venv\Scripts\activate        # Windows (PowerShell or cmd)
+# source .venv/bin/activate   # macOS / Linux
+
+pip install -r requirements.txt
+
+cd src
 python web_panel.py
 
 # Open in browser: http://YOUR-PC-IP:5000
 ```
+
+> **Prefer conda?** Use a conda environment instead of `venv` — ready to
+> copy‑paste:
+> ```bash
+> conda create -y -n kid-pc-monitor python=3.12
+> conda activate kid-pc-monitor
+> pip install -r requirements.txt
+> ```
 
 **Linux parent machine:** The web panel does not require `pywin32`; `requirements.txt` installs it only on Windows. From the repo root:
 

--- a/README.md
+++ b/README.md
@@ -67,12 +67,21 @@ pip install -r requirements.txt
 python scripts/install.py
 ```
 
-> **Which account to enter:** the installer must run elevated (as a parent/admin
-> account), but the monitor has to run inside the **kid's** session. So when it
-> asks for the *"Kid's Windows username"*, enter the **standard account the child
-> logs in with** — not the admin account you used to launch the installer. The
-> scheduled task is created to run as that user, triggered at their logon. If you
-> enter the wrong account, the task installs but never starts when the kid logs in.
+> ⚠️ **IMPORTANT — enter the KID's account, not yours.** The installer must run
+> elevated, so it is usually launched from a **parent/admin** account. But the
+> monitor has to run inside the **kid's** session. When the installer asks for
+> the *"Kid's Windows username"*, it shows the elevated (admin) account it
+> detected as a hint — **if the kid logs in with a different account (the normal
+> case), type that account instead.** Only accept the detected name if the
+> account you are installing for is the very same one you are logged in as.
+>
+> The scheduled task is created to run as the account you type, triggered at
+> **that** user's logon. Get this wrong and the task installs successfully but
+> **never starts when the kid logs in, and clicking "Run" does nothing** — with
+> no error and no log, which is very hard to diagnose. So double-check this one
+> prompt. You can confirm it later in Task Scheduler → the task's **General** tab
+> → *"When running the task, use the following user account"* should show the
+> **kid's** account.
 
 2. **On your PC (Windows or macOS; for Linux, see the Linux parent steps below):**
 ```bash
@@ -125,6 +134,10 @@ pip install -r requirements.txt
 python scripts/install.py           # Installs pc_control
 python scripts/install_web_panel.py # Installs web panel
 ```
+
+> ⚠️ When `install.py` asks for the *"Kid's Windows username"*, enter the
+> **standard account the child logs in with**, not the admin account you used to
+> run the installer. See the boxed note under Option A for why this matters.
 
 2. **On your phone:**
    - Open browser and go to `http://KIDS-PC-IP:5000`
@@ -224,6 +237,19 @@ This means restrictions **survive PC restarts** - kids can't bypass by rebooting
 - Restart pc_control.py
 - Check if LogonUI.exe detection works
 - See logs in console window
+
+### "Task installed but the agent never runs (port 9999 not listening; clicking Run does nothing)"
+- Almost always the **wrong user account**: the scheduled task was created for
+  the admin/parent account used to run the installer, not the kid's account, so
+  it never triggers at the kid's logon. Open Task Scheduler → the **KidPCMonitor**
+  task → **General** tab and check *"When running the task, use the following
+  user account"*. If it isn't the **kid's** account, re-run `python scripts/install.py`
+  as administrator and enter the **kid's** username when prompted.
+- It runs when you start it manually but not as a task: that confirms the above —
+  manual runs use *your* logged-in session, the task uses the account it was
+  created for.
+- Check the agent's logs in the **`src` folder** (the task's working directory):
+  `pc_control.log` (look for `Server started on port 9999`) and `pc_control.out.log`.
 
 ## 🛡️ Security Notes
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ pip install -r requirements.txt
 python scripts/install.py
 ```
 
+> **Which account to enter:** the installer must run elevated (as a parent/admin
+> account), but the monitor has to run inside the **kid's** session. So when it
+> asks for the *"Kid's Windows username"*, enter the **standard account the child
+> logs in with** — not the admin account you used to launch the installer. The
+> scheduled task is created to run as that user, triggered at their logon. If you
+> enter the wrong account, the task installs but never starts when the kid logs in.
+
 2. **On your PC (Windows or macOS; for Linux, see the Linux parent steps below):**
 ```bash
 git clone https://github.com/rookie7799/kid-pc-monitor.git

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -3,6 +3,11 @@ import os
 import sys
 from pathlib import Path
 
+# Port the pc_control agent listens on for the parent web panel to connect to.
+# Must match RemoteControlServer's default port in src/pc_control.py.
+AGENT_PORT = 9999
+FIREWALL_RULE_NAME = "Kid PC Monitor (agent)"
+
 def find_pc_control():
     """Locate pc_control.py relative to this installer.
 
@@ -270,6 +275,71 @@ def check_admin():
     except:
         return False
 
+def manual_firewall_command():
+    """The netsh command a user can run by hand to open the agent port."""
+    return (
+        f'netsh advfirewall firewall add rule '
+        f'name="{FIREWALL_RULE_NAME}" dir=in action=allow '
+        f'protocol=TCP localport={AGENT_PORT}'
+    )
+
+def configure_firewall():
+    """Add a Windows Firewall inbound rule for the agent port.
+
+    The agent listens on AGENT_PORT so the parent web panel can connect to it.
+    Without an inbound rule Windows Firewall blocks those connections, so the
+    panel can't reach the kid PC. We make this idempotent by deleting any rule
+    with the same name first, then adding a fresh one.
+    """
+    print(f"\n🔥 Windows Firewall: the agent listens on TCP port {AGENT_PORT} so")
+    print("   the parent web panel can connect to this PC.")
+    print("   Incoming connections must be allowed through the firewall.")
+
+    confirm = input(
+        f"\nAdd a firewall rule to allow incoming TCP port {AGENT_PORT}? (y/n): "
+    ).lower()
+    if confirm != 'y':
+        print("\nℹ️  Skipped. To allow it later, run this in an admin prompt:")
+        print(f"   {manual_firewall_command()}")
+        return False
+
+    # Remove any pre-existing rule with this name so we don't stack duplicates.
+    subprocess.run(
+        f'netsh advfirewall firewall delete rule name="{FIREWALL_RULE_NAME}"',
+        shell=True, capture_output=True, text=True
+    )
+
+    result = subprocess.run(
+        f'netsh advfirewall firewall add rule '
+        f'name="{FIREWALL_RULE_NAME}" dir=in action=allow '
+        f'protocol=TCP localport={AGENT_PORT}',
+        shell=True, capture_output=True, text=True
+    )
+
+    if result.returncode == 0:
+        print(f"\n✅ Firewall rule added: incoming TCP port {AGENT_PORT} allowed.")
+        return True
+    else:
+        print("\n❌ Could not add firewall rule automatically.")
+        if result.stdout.strip():
+            print(result.stdout.strip())
+        if result.stderr.strip():
+            print(result.stderr.strip())
+        print("\nYou can add it manually from an admin prompt:")
+        print(f"   {manual_firewall_command()}")
+        return False
+
+def remove_firewall_rule():
+    """Remove the agent firewall rule (used when removing the task)."""
+    result = subprocess.run(
+        f'netsh advfirewall firewall delete rule name="{FIREWALL_RULE_NAME}"',
+        shell=True, capture_output=True, text=True
+    )
+    if result.returncode == 0:
+        print(f"✅ Firewall rule '{FIREWALL_RULE_NAME}' removed.")
+    else:
+        print("ℹ️  No matching firewall rule found.")
+
 def remove_task():
     """Remove existing task"""
     task_name = "KidPCMonitor"
@@ -306,19 +376,27 @@ if __name__ == "__main__":
     
     if choice == "1":
         print("\nCreating scheduled task with battery-friendly settings...\n")
-        
+
         # Try PowerShell method first (most reliable)
-        if create_task_with_power_settings():
+        task_created = create_task_with_power_settings()
+        if task_created:
             print("\n✅ Setup complete! Task will run even on laptops using battery.")
         else:
             print("\nTrying alternative method...")
-            if create_task_simple_schtasks():
+            task_created = create_task_simple_schtasks()
+            if task_created:
                 print("\n✅ Setup complete using XML method!")
             else:
                 print("\n❌ Could not create task. Please check the error messages above.")
-    
+
+        # The task only matters if the parent web panel can reach the agent,
+        # which Windows Firewall blocks by default — offer to open the port.
+        if task_created:
+            configure_firewall()
+
     elif choice == "2":
         remove_task()
+        remove_firewall_rule()
     
     else:
         print("\nExiting...")

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -47,45 +47,67 @@ def get_script_path():
         else:
             print("❌ File not found or not a .py file. Please try again.")
 
+def get_target_user():
+    """Ask which user account the monitor should run under.
+
+    The installer runs elevated — typically as a parent/admin account — but the
+    task must run inside the *monitored* user's session, usually the kid's
+    standard account. os.getenv('USERNAME') here returns the elevated user, so
+    defaulting to it would bind the task to the wrong account and it would never
+    trigger when the kid logs in. Ask explicitly instead.
+    """
+    elevated_user = os.getenv('USERNAME')
+    print("\n👤 Which Windows account should be monitored?")
+    print(f"   This is the account the kid logs in with — NOT the admin")
+    print(f"   account running this installer (currently '{elevated_user}').")
+    target = input("\nKid's Windows username: ").strip()
+    if not target:
+        print(f"⚠️  No username entered; falling back to '{elevated_user}'.")
+        return elevated_user
+    return target
+
 def create_task_with_power_settings():
     """Create scheduled task that runs even on battery power"""
-    
+
     # Get script path from user
     script_path = get_script_path()
     if not script_path:
         return False
-    
+
     pythonw_path = sys.executable.replace('python.exe', 'pythonw.exe')
     task_name = "KidPCMonitor"
-    current_user = os.getenv('USERNAME')
-    
+    target_user = get_target_user()
+
     # Show what we're about to do
     print(f"\n📋 Task Configuration:")
     print(f"   Script: {script_path}")
     print(f"   Python: {pythonw_path}")
     print(f"   Task Name: {task_name}")
-    print(f"   User Account: {current_user}")
-    
+    print(f"   Monitored account: {target_user}")
+
     confirm = input("\nProceed with these settings? (y/n): ").lower()
     if confirm != 'y':
         print("❌ Setup cancelled.")
         return False
-    
+
     # PowerShell script to create task with specific power settings
     ps_script = f'''
     $ErrorActionPreference = 'Stop'
     try {{
         # Create the action
         $action = New-ScheduledTaskAction -Execute "{pythonw_path}" -Argument "{script_path}" -WorkingDirectory "{os.path.dirname(script_path)}"
-        
-        # Create multiple triggers
+
+        # Trigger when the monitored user logs on (scoped to that account so it
+        # fires for the kid's session, not the admin's). An AtStartup trigger is
+        # useless here because an interactive token only exists after logon.
         $triggers = @(
-            (New-ScheduledTaskTrigger -AtStartup),
-            (New-ScheduledTaskTrigger -AtLogon)
+            (New-ScheduledTaskTrigger -AtLogon -User "{target_user}")
         )
-        
-        # Create principal (run with current user)
-        $principal = New-ScheduledTaskPrincipal -UserId "{current_user}" -LogonType Interactive -RunLevel Highest
+
+        # Run as the monitored (kid) account. It's a standard user, so use the
+        # Limited run level — Highest would request an elevation it can't grant
+        # and can stop the task from starting.
+        $principal = New-ScheduledTaskPrincipal -UserId "{target_user}" -LogonType Interactive -RunLevel Limited
         
         # Create settings with power options
         $settings = New-ScheduledTaskSettingsSet `
@@ -143,8 +165,8 @@ def create_task_with_power_settings():
             
             if verify_result.returncode == 0:
                 print("\n✅ Task successfully created and verified!")
-                print(f"   - Triggers: At Startup + At Logon")
-                print(f"   - Running as: {current_user}")
+                print(f"   - Trigger: At logon of {target_user}")
+                print(f"   - Running as: {target_user}")
                 print("\nYou can verify in Task Scheduler (taskschd.msc)")
                 return True
             else:
@@ -169,12 +191,17 @@ def create_task_simple_schtasks():
     if not script_path:
         return False
     
-    python_path = sys.executable
+    # Use pythonw so no console window appears in the kid's session, matching
+    # the primary (PowerShell) method.
+    pythonw_path = sys.executable.replace('python.exe', 'pythonw.exe')
     task_name = "KidPCMonitor"
-    
+    target_user = get_target_user()
+
     print(f"\n📋 Creating task with XML method...")
-    
-    # Create XML with proper power settings
+
+    # Create XML with proper power settings. The trigger and principal are both
+    # scoped to the monitored (kid) account, and run at the Limited level since
+    # it's a standard, non-elevated user.
     xml_content = f'''<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
@@ -183,12 +210,14 @@ def create_task_simple_schtasks():
   <Triggers>
     <LogonTrigger>
       <Enabled>true</Enabled>
+      <UserId>{target_user}</UserId>
     </LogonTrigger>
   </Triggers>
   <Principals>
     <Principal id="Author">
+      <UserId>{target_user}</UserId>
       <LogonType>InteractiveToken</LogonType>
-      <RunLevel>HighestAvailable</RunLevel>
+      <RunLevel>LeastPrivilege</RunLevel>
     </Principal>
   </Principals>
   <Settings>
@@ -216,7 +245,7 @@ def create_task_simple_schtasks():
   </Settings>
   <Actions Context="Author">
     <Exec>
-      <Command>{python_path}</Command>
+      <Command>{pythonw_path}</Command>
       <Arguments>"{script_path}"</Arguments>
       <WorkingDirectory>{os.path.dirname(script_path)}</WorkingDirectory>
     </Exec>

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -275,6 +275,26 @@ def check_admin():
     except:
         return False
 
+def port_check_command():
+    """Return the OS-appropriate command to check if the agent port listens."""
+    if sys.platform.startswith('win'):
+        return f'netstat -an | findstr {AGENT_PORT}'
+    elif sys.platform == 'darwin':
+        # ss isn't available on macOS; lsof is the reliable option.
+        return f'lsof -nP -iTCP:{AGENT_PORT} -sTCP:LISTEN'
+    else:
+        # Linux and other Unixes: ss is the modern default.
+        return f'ss -tlnp | grep {AGENT_PORT}'
+
+def print_port_check_hint():
+    """Tell the user how to verify the agent is actually listening."""
+    print("\n" + "=" * 45)
+    print(f"💡 To verify the agent is listening on port {AGENT_PORT}, run:")
+    print(f"   {port_check_command()}")
+    print(f"\n   If nothing shows up, the agent isn't running. Run it in a")
+    print(f"   console to see why:  python \"{find_pc_control() or 'src/pc_control.py'}\"")
+    print("=" * 45)
+
 def manual_firewall_command():
     """The netsh command a user can run by hand to open the agent port."""
     return (
@@ -393,6 +413,7 @@ if __name__ == "__main__":
         # which Windows Firewall blocks by default — offer to open the port.
         if task_created:
             configure_firewall()
+            print_port_check_hint()
 
     elif choice == "2":
         remove_task()

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -286,25 +286,21 @@ def check_admin():
     except:
         return False
 
-def port_check_command():
-    """Return the OS-appropriate command to check if the agent port listens."""
-    if sys.platform.startswith('win'):
-        return f'netstat -an | findstr {AGENT_PORT}'
-    elif sys.platform == 'darwin':
-        # ss isn't available on macOS; lsof is the reliable option.
-        return f'lsof -nP -iTCP:{AGENT_PORT} -sTCP:LISTEN'
-    else:
-        # Linux and other Unixes: ss is the modern default.
-        return f'ss -tlnp | grep {AGENT_PORT}'
+def print_logon_start_hint(target_user):
+    """Explain when the agent actually starts.
 
-def print_port_check_hint(script_path=None):
-    """Tell the user how to verify the agent is actually listening."""
-    pc_control_path = script_path or find_pc_control() or 'src/pc_control.py'
+    The task runs with an Interactive logon type and the agent needs the kid's
+    desktop session (it shows dialogs, locks the workstation and watches the
+    foreground window). It therefore can't run while only the admin is logged
+    in — it starts on the kid's next logon via the AtLogon trigger. Checking
+    port 9999 right after install would show nothing, which is expected.
+    """
     print("\n" + "=" * 45)
-    print(f"💡 To verify the agent is listening on port {AGENT_PORT}, run:")
-    print(f"   {port_check_command()}")
-    print(f"\n   If nothing shows up, the agent isn't running. Run it in a")
-    print(f"   console to see why:  python \"{pc_control_path}\"")
+    print(f"💡 The agent starts automatically when '{target_user}' next logs in.")
+    print(f"   It runs inside that account's desktop session, so it won't be")
+    print(f"   running yet while you're signed in as the admin — that's normal.")
+    print(f"   Log in as '{target_user}' to start it (or, if that account is")
+    print(f"   already signed in, run: schtasks /run /tn \"KidPCMonitor\").")
     print("=" * 45)
 
 def manual_firewall_command():
@@ -424,7 +420,7 @@ if __name__ == "__main__":
         # which Windows Firewall blocks by default — offer to open the port.
         if task_created:
             configure_firewall()
-            print_port_check_hint(script_path)
+            print_logon_start_hint(target_user)
 
     elif choice == "2":
         remove_task()

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -48,35 +48,29 @@ def get_script_path():
             print("❌ File not found or not a .py file. Please try again.")
 
 def get_target_user():
-    """Ask which user account the monitor should run under.
-
-    The installer runs elevated — typically as a parent/admin account — but the
-    task must run inside the *monitored* user's session, usually the kid's
-    standard account. os.getenv('USERNAME') here returns the elevated user, so
-    defaulting to it would bind the task to the wrong account and it would never
-    trigger when the kid logs in. Ask explicitly instead.
-    """
-    elevated_user = os.getenv('USERNAME')
+    """Ask which user account the monitor should run under."""
+    elevated_user = os.getenv('USERNAME') or ''
     print("\n👤 Which Windows account should be monitored?")
     print(f"   This is the account the kid logs in with — NOT the admin")
     print(f"   account running this installer (currently '{elevated_user}').")
-    target = input("\nKid's Windows username: ").strip()
-    if not target:
-        print(f"⚠️  No username entered; falling back to '{elevated_user}'.")
-        return elevated_user
-    return target
+    while True:
+        target = input("\nKid's Windows username: ").strip()
+        if not target:
+            if not elevated_user:
+                print("❌ No username entered and USERNAME env var is not set. Please type the account name.")
+                continue
+            print(f"⚠️  No username entered; falling back to '{elevated_user}'.")
+            target = elevated_user
+        result = subprocess.run(['net', 'user', target], capture_output=True, text=True)
+        if result.returncode == 0:
+            return target
+        print(f"❌ Account '{target}' not found on this PC. Check the spelling and try again.")
+        print(f"   (Run 'net user' in a command prompt to list local accounts.)")
 
-def create_task_with_power_settings():
+def create_task_with_power_settings(script_path, target_user):
     """Create scheduled task that runs even on battery power"""
-
-    # Get script path from user
-    script_path = get_script_path()
-    if not script_path:
-        return False
-
-    pythonw_path = sys.executable.replace('python.exe', 'pythonw.exe')
+    pythonw_path = str(Path(sys.executable).parent / 'pythonw.exe')
     task_name = "KidPCMonitor"
-    target_user = get_target_user()
 
     # Show what we're about to do
     print(f"\n📋 Task Configuration:")
@@ -183,19 +177,10 @@ def create_task_with_power_settings():
         print(f"\n❌ Unexpected error: {e}")
         return False
     
-def create_task_simple_schtasks():
+def create_task_simple_schtasks(script_path, target_user):
     """Alternative using schtasks with XML template"""
-    
-    # Get script path from user
-    script_path = get_script_path()
-    if not script_path:
-        return False
-    
-    # Use pythonw so no console window appears in the kid's session, matching
-    # the primary (PowerShell) method.
-    pythonw_path = sys.executable.replace('python.exe', 'pythonw.exe')
+    pythonw_path = str(Path(sys.executable).parent / 'pythonw.exe')
     task_name = "KidPCMonitor"
-    target_user = get_target_user()
 
     print(f"\n📋 Creating task with XML method...")
 
@@ -252,22 +237,19 @@ def create_task_simple_schtasks():
   </Actions>
 </Task>'''
     
+    xml_path = os.path.join(os.path.dirname(script_path), 'task_config.xml')
     try:
-        # Write XML to temp file
-        with open('task_config.xml', 'w', encoding='utf-16') as f:
-            f.write(xml_content)
-        
-        # Import the task
-        result = subprocess.run(
-            f'schtasks /create /tn "{task_name}" /xml "task_config.xml" /f',
-            shell=True,
-            capture_output=True,
-            text=True
-        )
-        
-        # Clean up
-        os.remove('task_config.xml')
-        
+        try:
+            with open(xml_path, 'w', encoding='utf-16') as f:
+                f.write(xml_content)
+            result = subprocess.run(
+                f'schtasks /create /tn "{task_name}" /xml "{xml_path}" /f',
+                shell=True, capture_output=True, text=True
+            )
+        finally:
+            if os.path.exists(xml_path):
+                os.remove(xml_path)
+
         if result.returncode == 0:
             print("\n✅ Task created successfully with battery settings!")
             verify_task_settings(task_name)
@@ -275,7 +257,7 @@ def create_task_simple_schtasks():
         else:
             print(f"\n❌ Error: {result.stderr}")
             return False
-            
+
     except Exception as e:
         print(f"\n❌ Error: {e}")
         return False
@@ -315,13 +297,14 @@ def port_check_command():
         # Linux and other Unixes: ss is the modern default.
         return f'ss -tlnp | grep {AGENT_PORT}'
 
-def print_port_check_hint():
+def print_port_check_hint(script_path=None):
     """Tell the user how to verify the agent is actually listening."""
+    pc_control_path = script_path or find_pc_control() or 'src/pc_control.py'
     print("\n" + "=" * 45)
     print(f"💡 To verify the agent is listening on port {AGENT_PORT}, run:")
     print(f"   {port_check_command()}")
     print(f"\n   If nothing shows up, the agent isn't running. Run it in a")
-    print(f"   console to see why:  python \"{find_pc_control() or 'src/pc_control.py'}\"")
+    print(f"   console to see why:  python \"{pc_control_path}\"")
     print("=" * 45)
 
 def manual_firewall_command():
@@ -359,10 +342,7 @@ def configure_firewall():
     )
 
     result = subprocess.run(
-        f'netsh advfirewall firewall add rule '
-        f'name="{FIREWALL_RULE_NAME}" dir=in action=allow '
-        f'protocol=TCP localport={AGENT_PORT}',
-        shell=True, capture_output=True, text=True
+        manual_firewall_command(), shell=True, capture_output=True, text=True
     )
 
     if result.returncode == 0:
@@ -425,14 +405,16 @@ if __name__ == "__main__":
     
     if choice == "1":
         print("\nCreating scheduled task with battery-friendly settings...\n")
+        script_path = get_script_path()
+        target_user = get_target_user()
 
         # Try PowerShell method first (most reliable)
-        task_created = create_task_with_power_settings()
+        task_created = create_task_with_power_settings(script_path, target_user)
         if task_created:
             print("\n✅ Setup complete! Task will run even on laptops using battery.")
         else:
             print("\nTrying alternative method...")
-            task_created = create_task_simple_schtasks()
+            task_created = create_task_simple_schtasks(script_path, target_user)
             if task_created:
                 print("\n✅ Setup complete using XML method!")
             else:
@@ -442,7 +424,7 @@ if __name__ == "__main__":
         # which Windows Firewall blocks by default — offer to open the port.
         if task_created:
             configure_firewall()
-            print_port_check_hint()
+            print_port_check_hint(script_path)
 
     elif choice == "2":
         remove_task()

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -3,40 +3,44 @@ import os
 import sys
 from pathlib import Path
 
+def find_pc_control():
+    """Locate pc_control.py relative to this installer.
+
+    The repo layout is fixed: this script lives in scripts/ and pc_control.py
+    lives in src/, so we can find it without asking the user. We also check a
+    couple of fallback locations in case the files were moved.
+    """
+    installer_dir = os.path.dirname(os.path.abspath(__file__))
+    candidates = [
+        os.path.join(installer_dir, "..", "src", "pc_control.py"),  # repo layout
+        os.path.join(installer_dir, "pc_control.py"),               # alongside installer
+        os.path.join(os.getcwd(), "pc_control.py"),                 # current directory
+    ]
+    for candidate in candidates:
+        candidate = os.path.abspath(candidate)
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
 def get_script_path():
-    """Get the path to pc_control.py from user"""
-    print("📁 Where is pc_control.py located?")
-    print("\nOptions:")
-    print("1. Current directory")
-    print("2. Same directory as this installer")
-    print("3. Enter custom path")
-    
-    choice = input("\nChoice (1-3): ").strip()
-    
-    if choice == "1":
-        script_path = os.path.abspath("pc_control.py")
-    elif choice == "2":
-        script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "pc_control.py")
-    else:
-        while True:
-            custom_path = input("\nEnter full path to pc_control.py: ").strip()
-            # Remove quotes if user copied from explorer
-            custom_path = custom_path.strip('"').strip("'")
-            
-            if os.path.exists(custom_path) and custom_path.endswith('.py'):
-                script_path = os.path.abspath(custom_path)
-                break
-            else:
-                print("❌ File not found or not a .py file. Please try again.")
-    
-    # Verify the file exists
-    if not os.path.exists(script_path):
-        print(f"\n❌ Error: Could not find {script_path}")
-        print("Please make sure pc_control.py exists in the specified location.")
-        return None
-    
-    print(f"\n✅ Found: {script_path}")
-    return script_path
+    """Get the path to pc_control.py, auto-detecting when possible."""
+    script_path = find_pc_control()
+
+    if script_path:
+        print(f"✅ Found pc_control.py: {script_path}")
+        return script_path
+
+    # Auto-detection failed — fall back to asking the user.
+    print("⚠️  Could not auto-detect pc_control.py.")
+    while True:
+        custom_path = input("\nEnter full path to pc_control.py: ").strip()
+        # Remove quotes if user copied from explorer
+        custom_path = custom_path.strip('"').strip("'")
+
+        if os.path.exists(custom_path) and custom_path.endswith('.py'):
+            return os.path.abspath(custom_path)
+        else:
+            print("❌ File not found or not a .py file. Please try again.")
 
 def create_task_with_power_settings():
     """Create scheduled task that runs even on battery power"""

--- a/src/pc_control.py
+++ b/src/pc_control.py
@@ -46,6 +46,17 @@ logging.basicConfig(
     datefmt='%Y-%m-%d %H:%M:%S'
 )
 
+# When launched via pythonw.exe (as the scheduled task does) there is no
+# console, so sys.stdout/sys.stderr are None and the first print() raises
+# AttributeError, killing the agent before the server can bind port 9999.
+# Redirect them to a file so print() is safe and its output is captured.
+if sys.stdout is None or sys.stderr is None:
+    _console_log = open('pc_control.out.log', 'a', buffering=1, encoding='utf-8')
+    if sys.stdout is None:
+        sys.stdout = _console_log
+    if sys.stderr is None:
+        sys.stderr = _console_log
+
 class PCTimeControl:
     def __init__(self):
         self.lock_times = []


### PR DESCRIPTION
## Summary

Reworks the Windows agent installer (`scripts/install.py`) so the monitoring agent reliably runs under the kid's account, opens the firewall it needs, and survives running headless under `pythonw.exe`. Also clarifies the docs so parents set it up correctly the first time.

## Why

The installer used to install "successfully" yet leave the agent never actually listening on port 9999, because of several footguns: the scheduled task ran as the admin account used to run the installer rather than the kid's account, so it never triggered at the kid's logon; under `pythonw.exe` (which has no console) the agent's first `print()` raised `AttributeError` and killed the process before it could bind the port; Windows Firewall blocked inbound connections from the parent web panel; and a post-install "check port 9999 now" hint was misleading since the agent only starts once the kid logs in.

## What changed

**Installer (`scripts/install.py`)** — The scheduled task now runs as the monitored kid account (Interactive logon, Limited run level) and is triggered at that account's logon. The installer prompts for and validates the kid's Windows username with a `net user` check, auto-detects `pc_control.py` instead of always asking for its path, and adds an idempotent Windows Firewall rule for inbound TCP 9999 with a manual fallback command if it can't be added automatically. The misleading post-install port-check hint is replaced with an honest note that the agent starts on the kid's next logon.

**Agent (`src/pc_control.py`)** — When the agent is launched without a console (as the scheduled task does, via `pythonw.exe`), `stdout`/`stderr` are redirected to a log file so `print()` no longer crashes the agent before the server can start.

**Docs (`README.md`)** — Clarifies that the installer must be told the kid's account and not the admin's, drops the `pip install` step on kid PCs since the agent uses only the standard library, adds venv/conda setup guidance for the web panel, and documents a `netstat -an | findstr 9999` verification step with a note that the agent only listens after the kid logs in.

**Misc** — Ignore `.venv/`.

## Testing

Manually tested on Windows: the task is created under the kid account, fires at the kid's logon, and the agent listens on port 9999 once that account is logged in. `python -m py_compile scripts/install.py` passes.

## A note on how this was produced

The code in this PR was AI-assisted (written with Claude Code) but tested on a real Windows setup, with code reviews over the changes.
