### PR TITLE
fix: start run_monitor thread so time limits are actually enforced

### DIFF
--- a/src/pc_control.py
+++ b/src/pc_control.py
@@ -621,7 +621,12 @@ if __name__ == "__main__":
             "Server Error"
         )
         sys.exit(1)
-    
+
+    # Start the enforcement monitor only once the server is confirmed up, so a
+    # failed startup can't lock the screen on its way to sys.exit(1).
+    monitor_thread = threading.Thread(target=control.run_monitor, daemon=True)
+    monitor_thread.start()
+
     print("Server is running. Press Ctrl+C to stop.")
     
     try:


### PR DESCRIPTION
## What

Start the `run_monitor` enforcement thread on startup.

## Why

The monitor loop is constructed but **never started**, so in practice **no usage limit and no scheduled lock is ever enforced**. The thread is launched only after the remote server is confirmed up, so a failed startup still exits cleanly (`sys.exit(1)`) without locking the screen.

I split this out of #11 deliberately: #11 bundles several related fixes and may look too big to review at once. This is the single critical change — small and easy to test on its own, so it can be accepted quickly.

I still recommend merging #11 as well: I've been running it and **without it my kid's time limit is not enforced at all**. But that's your call — this PR is the minimal fix if you'd rather take the changes incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)