### PR TITLE
fix: keep enforcing time limits after the first lock

### DIFF
--- a/src/pc_control.py
+++ b/src/pc_control.py
@@ -322,18 +322,30 @@ class PCTimeControl:
         return False, ""
 
     def run_monitor(self):
-        """Main monitoring loop"""
+        """Main monitoring loop: enforces limits for the whole session.
+
+        Runs forever — it must NOT exit after the first lock, otherwise the kid
+        could unlock the screen and use the PC unrestricted for the rest of the
+        day. Locking only happens on the unlocked->over-limit transition so we
+        don't re-issue LockWorkStation every second while already at the lock
+        screen; monitor_activity clears is_locked when the screen is unlocked,
+        which re-arms enforcement if the limit is still exceeded.
+        """
         print("PC Time Control is running...")
         while True:
-            # Check and send warnings if approaching time limit
-            self.check_and_send_warnings()
+            try:
+                # Check and send warnings if approaching time limit
+                self.check_and_send_warnings()
 
-            # Check if time limit reached
-            should_lock, reason = self.check_time_limits()
-            if should_lock:
-                print(f"Locking PC: {reason}")
-                self.lock_pc()
-                break
+                # Check if time limit reached
+                should_lock, reason = self.check_time_limits()
+                if should_lock and not self.is_locked:
+                    print(f"Locking PC: {reason}")
+                    self.lock_pc()
+            except Exception as e:
+                # Never let a transient error kill the enforcement loop.
+                self.logger.error(f"Error in monitor loop: {e}")
+                print(f"[{datetime.now():%H:%M:%S}] Monitor loop error: {e}")
             time.sleep(1)
 
 # Simple Remote Control Server


### PR DESCRIPTION
## What

Keep the `run_monitor` loop running after the first lock instead of `break`ing out of it.

## Why

After locking once, `run_monitor` exited its loop. The kid could then simply **unlock the screen and use the PC unrestricted for the rest of the day**.

This PR:
- Removes the `break` so enforcement continues for the whole session.
- Only locks on the unlocked→over-limit transition (guarded by `is_locked`), so we don't re-issue `LockWorkStation` every second while already sitting at the lock screen. `monitor_activity` clears `is_locked` on unlock, which re-arms enforcement if the limit is still exceeded.
- Wraps the loop body in `try/except` so a transient error can't kill the enforcement thread and leave the PC unguarded.

I split this out of #11 deliberately: #11 bundles several related fixes and may look too big to review at once. This one is small and testable on its own.

Note: this is most useful together with the thread actually being started (see the companion PR #13). I still recommend merging #11 as well — I've been running it and without it my kid's time limit is not enforced. But it's your call whether to take these incrementally or merge #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)