### PR TITLE
fix: accurate pre-lock countdown + announce time left on login

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,22 @@ Parents and developers welcome! Please:
 2. Create a feature branch
 3. Submit a pull request
 
+### Running the tests
+
+The platform-independent logic has unit tests under `tests/`. They use only the Python standard library — no extra dependencies and no Windows required:
+
+```bash
+# From the repo root
+python tests/test_warning_logic.py
+```
+
+Each test file is runnable on its own and prints a line per case (and exits non-zero on failure). If you prefer, you can also run them with pytest:
+
+```bash
+pip install pytest   # optional
+pytest tests/
+```
+
 ### Recent Improvements (v2.0)
 - ✅ Grace period warnings (15, 5, 1 minute before lock)
 - ✅ Persistent state storage (settings survive restarts)

--- a/src/pc_control.py
+++ b/src/pc_control.py
@@ -69,6 +69,7 @@ class PCTimeControl:
         self.logger = logging.getLogger('PCTimeControl')
         self.warnings_sent = set()  # Track which warnings have been sent
         self.warning_intervals = [15, 5, 1]  # Warning times in minutes before lock
+        self.last_remaining = None  # Previous remaining minutes, for crossing detection
 
         # Log which user we're running as
         if self.should_monitor_user():
@@ -275,18 +276,36 @@ class PCTimeControl:
         return min_remaining
 
     def check_and_send_warnings(self):
-        """Check if warnings should be sent and send them"""
+        """Check if warnings should be sent and send them.
+
+        A warning fires only when the remaining time *crosses down* through a
+        threshold (the previous tick was above it, this tick is at or below it).
+        This avoids over-stating the time: if the kid is granted only 10
+        minutes, the 15-minute warning never fires because the time never
+        actually started above 15. last_remaining is reset to None whenever the
+        limit changes so the next limit re-arms crossing from a clean slate.
+        """
         time_remaining = self.get_time_remaining()
 
         if time_remaining is None:
+            self.last_remaining = None
+            return
+
+        previous = self.last_remaining
+        self.last_remaining = time_remaining
+
+        # Nothing to cross from on the first observation after a (re)set.
+        if previous is None:
             return
 
         # Check each warning interval
         for warning_mins in self.warning_intervals:
             warning_key = f"{warning_mins}min"
 
-            # If we're within the warning window and haven't sent this warning yet
-            if time_remaining <= warning_mins and warning_key not in self.warnings_sent:
+            # Fire only when this tick crosses the threshold from above and we
+            # haven't already sent it.
+            if (previous > warning_mins >= time_remaining
+                    and warning_key not in self.warnings_sent):
                 self.warnings_sent.add(warning_key)
 
                 if warning_mins == 1:
@@ -486,6 +505,7 @@ class RemoteControlServer:
                     self.pc_control.set_usage_limit(minutes)
                     self.pc_control.start_time = datetime.now()  # Reset start time when setting new limit
                     self.pc_control.warnings_sent.clear()  # Clear warnings for new limit
+                    self.pc_control.last_remaining = None  # Re-arm crossing detection
                     self.pc_control.save_state()  # Save state after setting limit
                     return f"Usage limit set to {minutes} minutes"
                 except ValueError:
@@ -521,6 +541,7 @@ class RemoteControlServer:
             elif command == "CLEAR_LOCK_TIMES":
                 self.pc_control.lock_times = []
                 self.pc_control.warnings_sent.clear()  # Clear warnings too
+                self.pc_control.last_remaining = None  # Re-arm crossing detection
                 self.pc_control.save_state()
                 self.logger.info("All scheduled lock times cleared")
                 return "All scheduled lock times cleared"
@@ -529,6 +550,7 @@ class RemoteControlServer:
                 self.pc_control.usage_limit = None
                 self.pc_control.lock_times = []
                 self.pc_control.warnings_sent.clear()
+                self.pc_control.last_remaining = None  # Re-arm crossing detection
                 self.pc_control.save_state()
                 self.logger.info("All limits and locks cleared")
                 return "All limits and locks cleared"

--- a/src/pc_control.py
+++ b/src/pc_control.py
@@ -15,7 +15,11 @@ import json
 
 import logging
 from pathlib import Path
-from warning_logic import warnings_to_send
+from warning_logic import (
+    warnings_to_send,
+    initial_remaining_notice,
+    format_remaining_message,
+)
 
 # ============================================
 # CONFIGURATION
@@ -295,6 +299,17 @@ class PCTimeControl:
 
         previous = self.last_remaining
         self.last_remaining = time_remaining
+
+        # On the first reading after a (re)set, tell a late-logging-in kid how
+        # much time is actually left instead of staying silent until the next
+        # interval is crossed.
+        notice = initial_remaining_notice(previous, time_remaining,
+                                          self.warning_intervals)
+        if notice is not None:
+            msg = format_remaining_message(notice)
+            self.show_message(msg, "Warning")
+            self.logger.info(f"Initial time notice: {notice:.2f} minutes remaining")
+            print(f"[{datetime.now():%H:%M:%S}] {msg}")
 
         for warning_mins in warnings_to_send(previous, time_remaining,
                                               self.warning_intervals,

--- a/src/pc_control.py
+++ b/src/pc_control.py
@@ -15,6 +15,7 @@ import json
 
 import logging
 from pathlib import Path
+from warning_logic import warnings_to_send
 
 # ============================================
 # CONFIGURATION
@@ -67,7 +68,7 @@ class PCTimeControl:
         self.current_user = getpass.getuser()
         self.state_file = 'pc_control_state.json'
         self.logger = logging.getLogger('PCTimeControl')
-        self.warnings_sent = set()  # Track which warnings have been sent
+        self.warnings_sent = set()  # Threshold minutes already announced this episode
         self.warning_intervals = [15, 5, 1]  # Warning times in minutes before lock
         self.last_remaining = None  # Previous remaining minutes, for crossing detection
 
@@ -278,7 +279,8 @@ class PCTimeControl:
     def check_and_send_warnings(self):
         """Check if warnings should be sent and send them.
 
-        A warning fires only when the remaining time *crosses down* through a
+        Delegates the crossing decision to warning_logic.warnings_to_send: a
+        warning fires only when the remaining time crosses down through a
         threshold (the previous tick was above it, this tick is at or below it).
         This avoids over-stating the time: if the kid is granted only 10
         minutes, the 15-minute warning never fires because the time never
@@ -294,28 +296,19 @@ class PCTimeControl:
         previous = self.last_remaining
         self.last_remaining = time_remaining
 
-        # Nothing to cross from on the first observation after a (re)set.
-        if previous is None:
-            return
+        for warning_mins in warnings_to_send(previous, time_remaining,
+                                              self.warning_intervals,
+                                              self.warnings_sent):
+            self.warnings_sent.add(warning_mins)
 
-        # Check each warning interval
-        for warning_mins in self.warning_intervals:
-            warning_key = f"{warning_mins}min"
+            if warning_mins == 1:
+                msg = "⚠️ Computer will lock in 1 minute!"
+            else:
+                msg = f"⚠️ Computer will lock in {warning_mins} minutes!"
 
-            # Fire only when this tick crosses the threshold from above and we
-            # haven't already sent it.
-            if (previous > warning_mins >= time_remaining
-                    and warning_key not in self.warnings_sent):
-                self.warnings_sent.add(warning_key)
-
-                if warning_mins == 1:
-                    msg = "⚠️ Computer will lock in 1 minute!"
-                else:
-                    msg = f"⚠️ Computer will lock in {warning_mins} minutes!"
-
-                self.show_message(msg, "Warning")
-                self.logger.info(f"Warning sent: {warning_mins} minutes remaining")
-                print(f"[{datetime.now():%H:%M:%S}] Warning: {warning_mins} minutes until lock")
+            self.show_message(msg, "Warning")
+            self.logger.info(f"Warning sent: {warning_mins} minutes remaining")
+            print(f"[{datetime.now():%H:%M:%S}] Warning: {warning_mins} minutes until lock")
 
     def check_time_limits(self):
         """Check if any time limits have been reached"""

--- a/src/warning_logic.py
+++ b/src/warning_logic.py
@@ -22,3 +22,35 @@ def warnings_to_send(previous, current, intervals, already_sent):
         return []
     return [w for w in intervals
             if previous > w >= current and w not in already_sent]
+
+
+def initial_remaining_notice(previous, current, intervals):
+    """Return the minutes to announce as an immediate one-off notice, or None.
+
+    On the first reading after a (re)set (previous is None) a kid who logs in
+    late would otherwise hear nothing until the time crosses the next interval
+    (e.g. log in with 12 minutes left and stay silent until 5). When the
+    remaining time is already at or below the largest interval, announce the
+    actual time left right away. Returns None when a notice isn't warranted --
+    no active limit, already expired, or still above the largest interval
+    (where the normal crossing warnings will cover it).
+    """
+    if previous is not None or current is None:
+        return None
+    if current <= 0 or current > max(intervals):
+        return None
+    return current
+
+
+def format_remaining_message(remaining_minutes):
+    """Human-readable countdown text for a given remaining time in minutes.
+
+    Under a minute is rendered in seconds with a save prompt so the kid knows
+    to act fast; otherwise whole minutes (floored, never over-stating).
+    """
+    if remaining_minutes < 1:
+        seconds = max(1, int(round(remaining_minutes * 60)))
+        return f"⚠️ Attention: {seconds} seconds left, save!"
+    minutes = int(remaining_minutes)
+    unit = "minute" if minutes == 1 else "minutes"
+    return f"⚠️ You have {minutes} {unit} left!"

--- a/src/warning_logic.py
+++ b/src/warning_logic.py
@@ -1,0 +1,24 @@
+"""Pure decision logic for the pre-lock countdown warnings.
+
+Dependency-free (no tkinter / Windows): given the previous and current
+remaining minutes, decide which warning thresholds to announce this tick.
+Kept separate from PCTimeControl so it can be unit-tested in isolation.
+"""
+
+
+def warnings_to_send(previous, current, intervals, already_sent):
+    """Return the warning thresholds (minutes) to fire this tick, in order.
+
+    A threshold fires only when the remaining time *crosses down* through it
+    -- the previous tick was strictly above it and the current tick is at or
+    below it -- and it has not already been sent. This avoids over-stating the
+    time: a threshold larger than the time the kid ever had is never crossed,
+    so a 10-minute grant never announces "15 minutes left".
+
+    ``previous`` is None on the first observation after a (re)set, in which
+    case nothing fires (there is no point to have crossed from yet).
+    """
+    if previous is None or current is None:
+        return []
+    return [w for w in intervals
+            if previous > w >= current and w not in already_sent]

--- a/tests/test_warning_logic.py
+++ b/tests/test_warning_logic.py
@@ -8,7 +8,11 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from warning_logic import warnings_to_send  # noqa: E402
+from warning_logic import (  # noqa: E402
+    warnings_to_send,
+    initial_remaining_notice,
+    format_remaining_message,
+)
 
 INTERVALS = [15, 5, 1]
 
@@ -69,7 +73,41 @@ def test_simulated_grants():
     check("30 sec", simulate(0.5), [])
 
 
+def test_initial_remaining_notice():
+    # Only on the first reading (previous is None).
+    check("not first reading -> none",
+          initial_remaining_notice(10, 8, INTERVALS), None)
+    # No active limit.
+    check("no limit -> none", initial_remaining_notice(None, None, INTERVALS), None)
+    # Already expired.
+    check("expired -> none", initial_remaining_notice(None, 0, INTERVALS), None)
+    # Above the largest interval: let the normal crossings handle it.
+    check("above top interval -> none",
+          initial_remaining_notice(None, 20, INTERVALS), None)
+    # Logging in below the top interval: announce the actual time left now.
+    check("login at 12 -> 12", initial_remaining_notice(None, 12, INTERVALS), 12)
+    check("login at exactly 15 -> 15",
+          initial_remaining_notice(None, 15, INTERVALS), 15)
+    check("login under a minute -> 0.5",
+          initial_remaining_notice(None, 0.5, INTERVALS), 0.5)
+
+
+def test_format_remaining_message():
+    check("12 min", format_remaining_message(12), "⚠️ You have 12 minutes left!")
+    check("1 min singular", format_remaining_message(1), "⚠️ You have 1 minute left!")
+    # Floors rather than over-stating.
+    check("7.9 min floors to 7",
+          format_remaining_message(7.9), "⚠️ You have 7 minutes left!")
+    # Under a minute switches to a seconds-based save prompt.
+    check("30 sec", format_remaining_message(0.5),
+          "⚠️ Attention: 30 seconds left, save!")
+    check("never zero seconds", format_remaining_message(0.005),
+          "⚠️ Attention: 1 seconds left, save!")
+
+
 if __name__ == "__main__":
     test_warnings_to_send()
     test_simulated_grants()
+    test_initial_remaining_notice()
+    test_format_remaining_message()
     print("\nAll warning_logic tests passed.")

--- a/tests/test_warning_logic.py
+++ b/tests/test_warning_logic.py
@@ -1,0 +1,75 @@
+"""Unit tests for the pre-lock countdown warning decision logic.
+
+Pure and dependency-free: run with `python tests/test_warning_logic.py` (or
+via pytest). No tkinter / Windows needed.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from warning_logic import warnings_to_send  # noqa: E402
+
+INTERVALS = [15, 5, 1]
+
+
+def check(name, got, want):
+    assert got == want, f"{name}: expected {want!r}, got {got!r}"
+    print(f"  ok: {name}")
+
+
+def simulate(grant, intervals=INTERVALS, step=1 / 60.0):
+    """Tick remaining time down from ``grant`` to 0, collecting fired warnings.
+
+    Mirrors run_monitor's loop: first observation has no previous value, then
+    remaining decreases by one second (1/60 min) each tick.
+    """
+    sent = set()
+    fired = []
+    previous = None
+    t = grant
+    while t >= -1e-9:
+        current = max(t, 0.0)
+        for w in warnings_to_send(previous, current, intervals, sent):
+            sent.add(w)
+            fired.append(w)
+        previous = current
+        t -= step
+    return fired
+
+
+def test_warnings_to_send():
+    # No previous reading (first tick after a reset): never fire.
+    check("first tick -> nothing", warnings_to_send(None, 10, INTERVALS, set()), [])
+    # No active limit (current is None): never fire.
+    check("no limit -> nothing", warnings_to_send(10, None, INTERVALS, set()), [])
+
+    # A single downward crossing fires exactly that threshold.
+    check("cross 5 -> [5]", warnings_to_send(5.01, 4.99, INTERVALS, set()), [5])
+    # Already-sent thresholds are not repeated.
+    check("cross 5 already sent -> []",
+          warnings_to_send(5.01, 4.99, INTERVALS, {5}), [])
+    # No crossing (both above the threshold): nothing.
+    check("no crossing -> []", warnings_to_send(20, 16, INTERVALS, set()), [])
+    # A big jump down can cross several thresholds at once.
+    check("jump past 15 and 5 -> [15, 5]",
+          warnings_to_send(20, 3, INTERVALS, set()), [15, 5])
+
+
+def test_simulated_grants():
+    # A full grant announces every threshold in order.
+    check("60 min", simulate(60), [15, 5, 1])
+    check("16 min", simulate(16), [15, 5, 1])
+    # The reported bug: a 10-minute grant must NOT announce "15 minutes".
+    check("10 min (no false 15)", simulate(10), [5, 1])
+    check("4 min", simulate(4), [1])
+    # The 1-minute "save your work" warning still fires near the end.
+    assert 1 in simulate(4), "1-minute save warning must fire"
+    # Sub-minute grant: nothing was ever crossed from above.
+    check("30 sec", simulate(0.5), [])
+
+
+if __name__ == "__main__":
+    test_warnings_to_send()
+    test_simulated_grants()
+    print("\nAll warning_logic tests passed.")


### PR DESCRIPTION
## Summary

Fixes a bug where the pre-lock countdown over-stated the time left, and improves the warning UX for kids who reach (or log in with) less than 15 minutes remaining.

## The bug

`check_and_send_warnings()` fired a warning whenever `time_remaining <= warning_mins`. With intervals `[15, 5, 1]`, a kid granted only 10 minutes immediately tripped the 15-minute warning and saw **"⚠️ Computer will lock in 15 minutes!"** — even though only 10 minutes ever existed. It printed the *threshold*, not the *actual* remaining time.

## The fix — crossing detection

A warning now fires only when the remaining time **crosses down through** a threshold (previous tick strictly above it, current tick at or below it). A threshold larger than the time the kid ever had is never crossed, so it never fires.

| Grant | Warnings shown |
|-------|----------------|
| 60 min | 15, 5, 1 |
| 16 min | 15, 5, 1 |
| **10 min** | **5, 1** (was wrongly showing 15) |
| 4 min | 1 |

`last_remaining` is reset wherever `warnings_sent` is cleared, so a downward limit change can't re-trip an over-stated warning.

## UX improvement — tell the kid the actual time on login

Because the agent runs per-session (scheduled task, "At Logon") and the usage clock is wall-clock based, a kid logging in **late** previously heard nothing until the countdown crossed the next interval — e.g. log in with 12 minutes left and stay silent until 5, or log in with under a minute and get locked with **no warning at all**.

Now, on the first reading after login/start, if the remaining time is already at or below the largest interval, the actual time left is announced immediately:

- **"⚠️ You have N minutes left!"** (floored, never over-stated), or
- **"⚠️ Attention: X seconds left, save!"** when under a minute — so the kid gets a chance to save even on a last-minute login.

The per-interval crossing warnings continue as before. The 1-minute "save your work" warning is unaffected and still fires.

## Tests

The crossing decision and the message formatting are extracted into a dependency-free `src/warning_logic.py` and covered by `tests/test_warning_logic.py` (stdlib only — no tkinter / Windows). Runs standalone or under pytest, matching the existing test convention:

```bash
python tests/test_warning_logic.py   # or: pytest tests/
```

## Commits

- fix: only warn for time thresholds actually crossed
- test: extract warning crossing logic and unit-test it
- docs: document running the tests (stdlib script or pytest)
- feat: announce actual time left on login, with sub-minute save prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
